### PR TITLE
fix(data): update lmdb pairs and imgs path

### DIFF
--- a/cn_clip/training/data.py
+++ b/cn_clip/training/data.py
@@ -40,9 +40,9 @@ class LMDBDataset(Dataset):
 
         # assert LMDB directories exist
         assert os.path.isdir(lmdb_path), "The LMDB directory {} of {} split does not exist!".format(lmdb_path, split)
-        lmdb_pairs = os.path.join(lmdb_path, "pairs")
+        lmdb_pairs = os.path.join(lmdb_path, split, "pairs")
         assert os.path.isdir(lmdb_pairs), "The LMDB directory {} of {} image-text pairs does not exist!".format(lmdb_pairs, split)
-        lmdb_imgs = os.path.join(lmdb_path, "imgs")
+        lmdb_imgs = os.path.join(lmdb_path, split, "imgs")
         assert os.path.isdir(lmdb_imgs), "The LMDB directory {} of {} image base64 strings does not exist!".format(lmdb_imgs, split)
 
         # open LMDB files


### PR DESCRIPTION
以 Flickr30k-CN 为例，lmdb目录是：
```
Flickr30k-CN/
    └── lmdb/
        ├── train
            ├── pairs
            ├── imgs
        ├── valid
            ├── pairs
            ├── imgs
        ├── test
            ├── pairs
            ├── imgs
```