### PR TITLE
add pai-dsw gallery notebook and warning about modelscope version

### DIFF
--- a/cn_clip/training/main.py
+++ b/cn_clip/training/main.py
@@ -258,7 +258,12 @@ def main():
         }
         assert args.teacher_model_name in teacher_model_dict, "Error: Valid teacher model name has not been built."
 
-        teacher_model = Model.from_pretrained(args.teacher_model_name)
+        try:
+            teacher_model = Model.from_pretrained(args.teacher_model_name)
+        except Exception as e:
+            print("An error occurred while loading the model:", e)
+            print("Maybe the transformer version is not compatible, recommend to use transformers >= 4.10.0 and <= 4.30.2")
+
         for k, v in teacher_model.state_dict().items():
             v.requires_grad = False
         

--- a/cn_clip/training/main.py
+++ b/cn_clip/training/main.py
@@ -261,12 +261,12 @@ def main():
         try:
             teacher_model = Model.from_pretrained(args.teacher_model_name)
         except Exception as e:
-            error_message = (
-                "An error occurred while loading the model: {}\n"
-                "Maybe the transformer version is not compatible, "
-                "recommend to use transformers >= 4.10.0 and <= 4.30.2".format(e)
-            )
-            raise RuntimeError(error_message)
+            if "Unexpected key(s) in state_dict" in str(e):
+                error_message = (
+                    "An error occurred while loading the model: {}\n"
+                    "Maybe you should update modelscope. ".format(e)
+                )
+                raise RuntimeError(error_message)
 
         for k, v in teacher_model.state_dict().items():
             v.requires_grad = False

--- a/cn_clip/training/main.py
+++ b/cn_clip/training/main.py
@@ -261,8 +261,12 @@ def main():
         try:
             teacher_model = Model.from_pretrained(args.teacher_model_name)
         except Exception as e:
-            print("An error occurred while loading the model:", e)
-            print("Maybe the transformer version is not compatible, recommend to use transformers >= 4.10.0 and <= 4.30.2")
+            error_message = (
+                "An error occurred while loading the model: {}\n"
+                "Maybe the transformer version is not compatible, "
+                "recommend to use transformers >= 4.10.0 and <= 4.30.2".format(e)
+            )
+            raise RuntimeError(error_message)
 
         for k, v in teacher_model.state_dict().items():
             v.requires_grad = False

--- a/distillation.md
+++ b/distillation.md
@@ -59,5 +59,5 @@
 </p>
 
 
-## Future Action
-将会在阿里云官网上线相关的解决方案的Jupyter Notebook，提供更加清晰的实例教学，敬请期待。
+## 快速体验
+相关解决方案已经上线阿里云[PAI-DSW Gallery](https://gallery.pai-ml.com/#/preview/deepLearning/cv/cn_clip_distillation)。在PAI-DSW Gallery提供对应的Notebook，支持用户利用自有数据构建专属搜索模型。

--- a/distillation.md
+++ b/distillation.md
@@ -11,6 +11,7 @@
 + Pytorch 1.12及以上版本。
 + [requirements.txt](requirements.txt)要求的其他依赖项
 + **ModelScope**：通过执行`pip install modelscope`安装ModelScope。
++ 为了配合**ModelScope**的使用，**transformers**版本最好控制在(4.10.0, 4.30.2)之间。
 
 ## 在Chinese-CLIP中用起来！
 

--- a/distillation.md
+++ b/distillation.md
@@ -11,7 +11,6 @@
 + Pytorch 1.12及以上版本。
 + [requirements.txt](requirements.txt)要求的其他依赖项
 + **ModelScope**：通过执行`pip install modelscope`安装ModelScope。
-+ 为了配合**ModelScope**的使用，**transformers**版本最好控制在(4.10.0, 4.30.2)之间。
 
 ## 在Chinese-CLIP中用起来！
 

--- a/distillation_En.md
+++ b/distillation_En.md
@@ -9,8 +9,9 @@ Here we provide an example of knowledge distillation for Chinese-CLIP fine-tunin
 + Nvidia GPUs **with Turning, Ampere, Ada or Hopper architecture** (such as H100, A100, RTX 3090, T4, and RTX 2080). Please refer to [this document](https://en.wikipedia.org/wiki/CUDA#GPUs_supported) for the corresponding GPUs of each Nvidia architecture.
 + CUDA 11.4 and above.
 + PyTorch 1.12 and above.
-+ **ModelScope**：Install FlashAttention by executing `pip install modelscope`.
 + Other dependencies as required in [requirements.txt](requirements.txt).
++ **ModelScope**：Install FlashAttention by executing `pip install modelscope`.
++ In order to cooperate with the use of **ModelScope**, the version of **transformers** is best controlled between (4.10.0, 4.30.2).
 
 ## Use it in Chinese-CLIP!
 It is not complicated to apply knowledge distillation to the image side in Chinese-CLIP finetune. Just add the `--distllation` configuration item to the sh script of finetune.

--- a/distillation_En.md
+++ b/distillation_En.md
@@ -56,5 +56,5 @@ Advantages of our approach:
     <img src="examples/image_retrieval_result2.jpg" width="400" /><br>
 </p>
 
-## Future Action
-The Jupyter Notebook of related solutions will be launched on the Alibaba Cloud official website, which will provide a more clear example for usage. Stay tuned for this!
+## Quick Start
+Related solutions have been launched on Alibaba Cloud [PAI-DSW Gallery](https://gallery.pai-ml.com/#/preview/deepLearning/cv/cn_clip_distillation). The corresponding Notebook is provided in PAI-DSW Gallery to support users to build exclusive search models using their own data.

--- a/distillation_En.md
+++ b/distillation_En.md
@@ -11,7 +11,6 @@ Here we provide an example of knowledge distillation for Chinese-CLIP fine-tunin
 + PyTorch 1.12 and above.
 + Other dependencies as required in [requirements.txt](requirements.txt).
 + **ModelScope**：Install FlashAttention by executing `pip install modelscope`.
-+ In order to cooperate with the use of **ModelScope**, the version of **transformers** is best controlled between (4.10.0, 4.30.2).
 
 ## Use it in Chinese-CLIP!
 It is not complicated to apply knowledge distillation to the image side in Chinese-CLIP finetune. Just add the `--distllation` configuration item to the sh script of finetune.


### PR DESCRIPTION
- Added Alibaba Cloud PAI-DSW Gallery link related to distillation.

- modelscope version：There may be a problem with calling modelscope to load the model. You need to upgrade the modelscope version to the latest one. 

- transformers version: Also note that the transformers version cannot be too low (less than 4.10.0).

Tips: The latest version of modelscope (1.9.1) can cover the latest transfomers version (4.33.2), and the version should not be lower than (4.10.0). The commonly used version of modelscope (1.9.0) currently supports transfomers (4.10.0, 4.30.2).
